### PR TITLE
Add .owner to get request

### DIFF
--- a/docs/twitter/twitter-reverse-lookup.html
+++ b/docs/twitter/twitter-reverse-lookup.html
@@ -149,7 +149,8 @@
 
 const handle = &quot;bonfida&quot;;
 
-const registry = await getTwitterRegistry(connection, handle);
+//Returns the public key, string, associated with handle
+const registry = await getTwitterRegistry(connection, handle).owner.toString();
 </code></pre>
 
                     </main>


### PR DESCRIPTION
Existing code returns the NameRegistryState object that includes BN version of associated keys. Adding .owner, and toString, returns the address the user is looking for.