### PR TITLE
Add: Add listings endpoint documentation

### DIFF
--- a/sns-book/src/SUMMARY.md
+++ b/sns-book/src/SUMMARY.md
@@ -51,6 +51,7 @@
 - [SNS API](sns-api/README.md)
 
   - [Categories](sns-api/categories.md)
+  - [Listings](sns-api/listings.md)
   - [Sales](sns-api/sales.md)
   - [Volumes](sns-api/volumes.md)
   - [Owners](sns-api/owners.md)

--- a/sns-book/src/sns-api/README.md
+++ b/sns-book/src/sns-api/README.md
@@ -47,6 +47,13 @@ enum PlatformEnum {
     Tensor = 32,
     GoatSwap = 33,
     Hadeswap = 34,
+    AuctionHouse = 35,
+    CategoryOffer = 36,
+    NightMarket = 37,
+    Cardinal = 38,
+    MECCSwap = 39,
+    SniperMarket = 40,
+    Okx = 41,
 }
 ```
 

--- a/sns-book/src/sns-api/listings.md
+++ b/sns-book/src/sns-api/listings.md
@@ -1,0 +1,51 @@
+## Listings
+
+### Listing Details
+
+This endpoint can be used to retrieve the listing details of a specific domain. The response is a JSON object with the below structure if the domain is listed, or null if the domain is not.
+
+| Key | Type    | Description                                     |
+| --- | ------- | ----------------------------------------------- |
+| d   | String  | The domain name                                 |
+| p   | Float   | The price of the domain                         |
+| q   | String  | The currency of the listing                     |
+| a   | Integer | The availability ID                             |
+| l   | Byte    | Language code                                   |
+| up  | Float   | The price in USD                                |
+| e   | Boolean | Indicates if the domain has an emoji            |
+| r   | Boolean | Indicates if the domain is rare                 |
+| do  | Boolean | Indicates if the domain contains digits only    |
+| lo  | Boolean | Indicates if the domain contains letters only   |
+| le  | Byte    | The length of the domain name                   |
+| fp  | Boolean | Indicates if the price is fixed                 |
+| me  | Boolean | Indicates if the domain is listed on Magic Eden |
+| pa  | Boolean | Indicates if the domain is a palindrome         |
+| ca  | Array   | A list of categories the domain belongs to      |
+
+> Request
+
+```
+GET /v2/listings/listing/{domain}
+```
+
+> Response
+
+```json
+{
+  "d": "bonfida.sol",
+  "p": 100.0,
+  "q": "USDC",
+  "a": 2,
+  "l": 0,
+  "up": 100.0,
+  "e": false,
+  "r": true,
+  "do": false,
+  "lo": true,
+  "le": 7,
+  "fp": true,
+  "me": false,
+  "pa": false,
+  "ca": []
+}
+```

--- a/sns-book/src/sns-api/listings.md
+++ b/sns-book/src/sns-api/listings.md
@@ -4,23 +4,23 @@
 
 This endpoint can be used to retrieve the listing details of a specific domain. The response is a JSON object with the below structure if the domain is listed, or null if the domain is not.
 
-| Key | Type    | Description                                     |
-| --- | ------- | ----------------------------------------------- |
-| d   | String  | The domain name                                 |
-| p   | Float   | The price of the domain                         |
-| q   | String  | The currency of the listing                     |
-| a   | Integer | The availability ID                             |
-| l   | Byte    | Language code                                   |
-| up  | Float   | The price in USD                                |
-| e   | Boolean | Indicates if the domain has an emoji            |
-| r   | Boolean | Indicates if the domain is rare                 |
-| do  | Boolean | Indicates if the domain contains digits only    |
-| lo  | Boolean | Indicates if the domain contains letters only   |
-| le  | Byte    | The length of the domain name                   |
-| fp  | Boolean | Indicates if the price is fixed                 |
-| me  | Boolean | Indicates if the domain is listed on Magic Eden |
-| pa  | Boolean | Indicates if the domain is a palindrome         |
-| ca  | Array   | A list of categories the domain belongs to      |
+| Key | Type                  | Description                                         |
+| --- | --------------------- | --------------------------------------------------- |
+| d   | String                | The domain name                                     |
+| p   | Float (`f32`)         | The price of the domain                             |
+| q   | String                | The token mint of the listing                       |
+| a   | Enum (`u8`)           | The availability ID (see `PlatformEnum` definition) |
+| l   | Enum (`u8`)           | Language code (see definition below)                |
+| up  | Float (`f32`)         | The price in USD                                    |
+| e   | Boolean               | Indicates if the domain has an emoji                |
+| r   | Boolean               | Indicates if the domain is rare                     |
+| do  | Boolean               | Indicates if the domain contains digits only        |
+| lo  | Boolean               | Indicates if the domain contains letters only       |
+| le  | Integer               | The length of the domain name                       |
+| fp  | Boolean               | Indicates if the listing is a fixed price offer     |
+| me  | Boolean               | Indicates if the domain is listed on Magic Eden     |
+| pa  | Boolean               | Indicates if the domain is a palindrome             |
+| ca  | Array (`Vec<String>`) | A list of categories the domain belongs to          |
 
 > Request
 
@@ -47,5 +47,18 @@ GET /v2/listings/listing/{domain}
   "me": false,
   "pa": false,
   "ca": []
+}
+```
+
+```rust
+pub enum Language {
+    English = 0,
+    Cyrillic = 1,
+    Chinese = 2,
+    Japanese = 3,
+    Emoji = 4,
+    Unauthorized = 5,
+    Korean = 6,
+    Arabic = 7,
 }
 ```


### PR DESCRIPTION
The purpose of this PR is to begin adding documentation for the listings endpoints. It is part of a broader push to update the SNS API documentation. 

Details of the /listings/listing/{domain} endpoint specifically were added. 